### PR TITLE
多单词本高亮和导出支持

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -40,6 +40,19 @@
     }
 
     chrome.runtime.onMessage.addListener(handleMessage);
+
+    chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+        if (request.type === 'wordbookUpdated') {
+            // 通知所有标签页刷新高亮状态
+            chrome.tabs.query({}, (tabs) => {
+                tabs.forEach(tab => {
+                    chrome.tabs.sendMessage(tab.id, {
+                        type: 'refreshHighlight'
+                    }).catch(() => {});  // 忽略不支持的标签页错误
+                });
+            });
+        }
+    });
 } (
     function(global) {
         'use strict';

--- a/src/js/content-highlight.js
+++ b/src/js/content-highlight.js
@@ -87,15 +87,13 @@
             try {
                 console.log('Initializing highlighter...');
                 
-                const bookId = await this.getCurrentBookId();
-                console.log('Current book ID:', bookId);
-                
                 if (!window.wordbookStorageModule) {
                     console.error('wordbookStorageModule not found');
                     return;
                 }
 
-                const words = await window.wordbookStorageModule.WordbookStorage.load(bookId);
+                // 获取所有单词本中的单词
+                const words = await window.wordbookStorageModule.WordbookStorage.loadAllWords();
                 console.log('Loaded words:', words?.length || 0);
                 
                 if (!words || words.length === 0) return;
@@ -133,11 +131,6 @@
             } catch (error) {
                 console.error('Failed to initialize highlighter:', error);
             }
-        }
-
-        async getCurrentBookId() {
-            return await chrome.storage.local.get('bookId')
-                .then(result => result.bookId || 0);
         }
 
         initPopover() {

--- a/src/js/options-anki.js
+++ b/src/js/options-anki.js
@@ -3,6 +3,53 @@
 
     const ankiService = new AnkiService();
     
+    function showMessage(message, type = 'success') {
+        const $msg = $(`
+            <div class="alert alert-${type} alert-dismissible fade show" role="alert">
+                ${message}
+                <button type="button" class="close" data-dismiss="alert">
+                    <span>&times;</span>
+                </button>
+            </div>
+        `);
+        
+        $('.card-body').prepend($msg);
+        
+        setTimeout(() => {
+            $msg.alert('close');
+        }, 3000);
+    }
+
+    async function saveAnkiSettings(showSaveMessage = true) {
+        const ankiSettings = {
+            enabled: $('#enableAnkiExport').prop('checked'),
+            deckName: $('#ankiDeck').val(),
+            exportPhonetic: $('#exportPhonetic').prop('checked'),
+            exportAudio: $('#exportAudio').prop('checked'),
+            exportMeaning: $('#exportMeaning').prop('checked'),
+            exportSentence: $('#exportSentence').prop('checked'),
+            exportImage: $('#exportImage').prop('checked'),
+            exportVariants: $('#exportVariants').prop('checked'),
+            exportPhrases: $('#exportPhrases').prop('checked'),
+            exportSynonyms: $('#exportSynonyms').prop('checked'),
+            exportAntonyms: $('#exportAntonyms').prop('checked'),
+            exportEnMeans: $('#exportEnMeans').prop('checked'),
+            autoExport: $('#autoExport').prop('checked')
+        };
+
+        try {
+            await chrome.storage.local.set({ ankiSettings });
+            if (showSaveMessage) {
+                showMessage('设置已保存');
+            }
+        } catch (error) {
+            console.error('Failed to save Anki settings:', error);
+            if (showSaveMessage) {
+                showMessage('保存设置失败', 'danger');
+            }
+        }
+    }
+
     async function initAnkiSettings() {
         const $ankiStatus = $('#ankiStatus');
         const $ankiSettingsDetails = $('#ankiSettingsDetails');
@@ -23,13 +70,14 @@
                 exportPhrases: true,
                 exportSynonyms: true,
                 exportAntonyms: true,
-                exportEnMeans: true
+                exportEnMeans: true,
+                autoExport: true  // 默认启用自动导出
             };
 
             // 设置开关状态
             $enableAnkiExport.prop('checked', ankiSettings.enabled);
 
-            // 设置导出选项的值（不管是否启用都先设置好）
+            // 设置导出选项的值
             $('#exportPhonetic').prop('checked', ankiSettings.exportPhonetic);
             $('#exportAudio').prop('checked', ankiSettings.exportAudio);
             $('#exportMeaning').prop('checked', ankiSettings.exportMeaning);
@@ -40,6 +88,7 @@
             $('#exportSynonyms').prop('checked', ankiSettings.exportSynonyms);
             $('#exportAntonyms').prop('checked', ankiSettings.exportAntonyms);
             $('#exportEnMeans').prop('checked', ankiSettings.exportEnMeans);
+            $('#autoExport').prop('checked', ankiSettings.autoExport);
 
             // 如果功能已启用，则尝试连接 Anki
             if (ankiSettings.enabled) {
@@ -125,52 +174,6 @@
                 .html('初始化设置失败')
                 .show();
         }
-    }
-
-    async function saveAnkiSettings(showMessage = true) {
-        const ankiSettings = {
-            enabled: $('#enableAnkiExport').prop('checked'),
-            deckName: $('#ankiDeck').val(),
-            exportPhonetic: $('#exportPhonetic').prop('checked'),
-            exportAudio: $('#exportAudio').prop('checked'),
-            exportMeaning: $('#exportMeaning').prop('checked'),
-            exportSentence: $('#exportSentence').prop('checked'),
-            exportImage: $('#exportImage').prop('checked'),
-            exportVariants: $('#exportVariants').prop('checked'),
-            exportPhrases: $('#exportPhrases').prop('checked'),
-            exportSynonyms: $('#exportSynonyms').prop('checked'),
-            exportAntonyms: $('#exportAntonyms').prop('checked'),
-            exportEnMeans: $('#exportEnMeans').prop('checked')
-        };
-
-        try {
-            await chrome.storage.local.set({ ankiSettings });
-            if (showMessage) {
-                showMessage('设置已保存');
-            }
-        } catch (error) {
-            console.error('Failed to save Anki settings:', error);
-            if (showMessage) {
-                showMessage('保存设置失败', 'danger');
-            }
-        }
-    }
-
-    function showMessage(message, type = 'success') {
-        const $msg = $(`
-            <div class="alert alert-${type} alert-dismissible fade show" role="alert">
-                ${message}
-                <button type="button" class="close" data-dismiss="alert">
-                    <span>&times;</span>
-                </button>
-            </div>
-        `);
-        
-        $('.card-body').prepend($msg);
-        
-        setTimeout(() => {
-            $msg.alert('close');
-        }, 3000);
     }
 
     // 初始化

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -183,9 +183,8 @@
                 // 同步失败不阻止导出，继续使用本地数据
             }
             
-            // 2. 获取当前单词本的所有单词
-            const bookId = $('#wordbookSelect').val() || await storageModule.get('bookId') || 0;
-            const words = await window.wordbookStorageModule.WordbookStorage.load(bookId);
+            // 2. 获取所有单词本的所有单词
+            const words = await window.wordbookStorageModule.WordbookStorage.loadAllWords();
             
             if (!words || words.length === 0) {
                 showMessage('没有找到收藏的单词');

--- a/src/js/services/anki-service.js
+++ b/src/js/services/anki-service.js
@@ -317,6 +317,7 @@
                 const settings = await chrome.storage.local.get(['ankiSettings']);
                 const ankiSettings = settings.ankiSettings || {
                     enabled: false,
+                    autoExport: true,
                     deckName: 'English Vocabulary',
                     exportPhonetic: true,
                     exportAudio: true,
@@ -330,8 +331,8 @@
                     exportEnMeans: true
                 };
 
-                // 如果功能未启用，直接返回
-                if (!ankiSettings.enabled) {
+                // 如果功能未启用或自动导出被禁用，直接返回
+                if (!ankiSettings.enabled || !ankiSettings.autoExport) {
                     return;
                 }
 

--- a/src/js/services/anki-service.js
+++ b/src/js/services/anki-service.js
@@ -331,8 +331,8 @@
                     exportEnMeans: true
                 };
 
-                // 如果功能未启用或自动导出被禁用，直接返回
-                if (!ankiSettings.enabled || !ankiSettings.autoExport) {
+                // 如果功能未启用，直接返回
+                if (!ankiSettings.enabled) {
                     return;
                 }
 

--- a/src/js/word-detail.js
+++ b/src/js/word-detail.js
@@ -158,9 +158,12 @@
                 if (collected) {
                     try {
                         const settings = await chrome.storage.local.get(['ankiSettings']);
-                        const ankiSettings = settings?.ankiSettings || { enabled: false };  // 默认为 false
+                        const ankiSettings = settings?.ankiSettings || { 
+                            enabled: false,
+                            autoExport: true  // 添加默认的自动导出设置
+                        };
 
-                        if (ankiSettings.enabled) {
+                        if (ankiSettings.enabled && ankiSettings.autoExport) {
                             const ankiService = new AnkiService();
                             await ankiService.addNote(
                                 data.word_basic_info.word,
@@ -180,13 +183,13 @@
                                 data.antonyms || [],
                                 data.en_means || []
                             );
-                            showMessage('已收藏并导出到Anki');
+                            showMessage('已收藏并同步到 Anki');
                         } else {
-                            showMessage('已收藏');  // 当 Anki 导出功能关闭时只显示已收藏
+                            showMessage('已收藏');  // 当 Anki 导出功能关闭或自动导出关闭时只显示已收藏
                         }
                     } catch (error) {
                         console.error('Export to Anki failed:', error);
-                        showMessage('已收藏，但导出到Anki失败：' + error.message);
+                        showMessage('已收藏，但同步到 Anki 失败：' + error.message);
                     }
                 } else {
                     showMessage('已取消收藏');

--- a/src/js/word-detail.js
+++ b/src/js/word-detail.js
@@ -160,32 +160,14 @@
                         const settings = await chrome.storage.local.get(['ankiSettings']);
                         const ankiSettings = settings?.ankiSettings || { 
                             enabled: false,
-                            autoExport: true  // 添加默认的自动导出设置
+                            autoExport: true
                         };
 
                         if (ankiSettings.enabled && ankiSettings.autoExport) {
-                            const ankiService = new AnkiService();
-                            await ankiService.addNote(
-                                data.word_basic_info.word,
-                                data.word_basic_info.accent_uk,
-                                data.chn_means.map(m => ({
-                                    type: m.mean_type,
-                                    mean: m.mean
-                                })),
-                                data.sentences?.[0]?.img_uri ? 
-                                    'https://7n.bczcdn.com' + data.sentences[0].img_uri : '',
-                                data.sentences?.[0]?.sentence || '',
-                                data.sentences?.[0]?.sentence_trans || '',
-                                'https://7n.bczcdn.com' + data.word_basic_info.accent_uk_audio_uri,
-                                data.variant_info || null,
-                                data.short_phrases || [],
-                                data.synonyms || [],
-                                data.antonyms || [],
-                                data.en_means || []
-                            );
+                            await exportToAnki(data);
                             showMessage('已收藏并同步到 Anki');
                         } else {
-                            showMessage('已收藏');  // 当 Anki 导出功能关闭或自动导出关闭时只显示已收藏
+                            showMessage('已收藏');
                         }
                     } catch (error) {
                         console.error('Export to Anki failed:', error);

--- a/src/js/word-webui-popover.js
+++ b/src/js/word-webui-popover.js
@@ -279,9 +279,12 @@
                     if (collected) {
                         try {
                             const settings = await chrome.storage.local.get(['ankiSettings']);
-                            const ankiSettings = settings?.ankiSettings || { enabled: false };
+                            const ankiSettings = settings?.ankiSettings || { 
+                                enabled: false,
+                                autoExport: true  // 添加默认的自动导出设置
+                            };
 
-                            if (ankiSettings.enabled) {
+                            if (ankiSettings.enabled && ankiSettings.autoExport) {  // 增加 autoExport 条件判断
                                 const ankiService = new window.AnkiService();
                                 await ankiService.addNote(
                                     data.word_basic_info.word,
@@ -301,13 +304,13 @@
                                     data.antonyms || [],
                                     data.en_means || []
                                 );
-                                $supportEl.trigger('baicizhanHelper:alert', ['已收藏并导出到Anki']);
+                                $supportEl.trigger('baicizhanHelper:alert', ['已收藏并同步到 Anki']);
                             } else {
                                 $supportEl.trigger('baicizhanHelper:alert', ['已收藏']);
                             }
                         } catch (error) {
                             console.error('Export to Anki failed:', error);
-                            $supportEl.trigger('baicizhanHelper:alert', ['已收藏，但导出到Anki失败：' + error.message]);
+                            $supportEl.trigger('baicizhanHelper:alert', ['已收藏，但同步到 Anki 失败：' + error.message]);
                         }
                     } else {
                         $supportEl.trigger('baicizhanHelper:alert', ['已取消收藏']);

--- a/src/js/wordbook-storage.js
+++ b/src/js/wordbook-storage.js
@@ -97,70 +97,27 @@
         });
     };
 
-    // 缓存相关常量
-    const CACHE_KEY = 'wordbook-cache';
-    const CACHE_EXPIRE_TIME = 5 * 60 * 1000; // 5分钟缓存过期
-
-    // 缓存结构
-    let cache = {
-        words: [],
-        timestamp: 0
-    };
-
     WordbookStorage.loadAllWords = async function() {
-        // 1. 检查缓存
-        if (cache.words.length > 0 && 
-            Date.now() - cache.timestamp < CACHE_EXPIRE_TIME) {
-            console.log('返回缓存的单词数据:', cache.words.length);
-            return cache.words;
-        }
-
-        // 1. 获取所有 storage keys
-        const items = await chrome.storage.local.get(null);
-        const wordbookKeys = Object.keys(items).filter(key => key.startsWith(KEY_PREFIX));
+        // 1. 先获取所有 keys
+        const keys = await chrome.storage.local.get(null).then(items => 
+            Object.keys(items).filter(key => key.startsWith(KEY_PREFIX))
+        );
         
-        // 2. 直接从 items 中提取数据，避免二次查询
-        const allWords = wordbookKeys.reduce((acc, key) => {
-            const words = items[key] || [];
-            return acc.concat(words);
-        }, []);
+        // 2. 并行加载所有单词本
+        const wordbooks = await Promise.all(
+            keys.map(key => chrome.storage.local.get(key))
+        );
         
-        // 3. 更新缓存
-        cache.words = allWords;
-        cache.timestamp = Date.now();
-        console.log('更新缓存，单词数:', allWords.length);
+        // 3. 使用 Map 合并去重
+        const uniqueWords = new Map();
+        wordbooks.forEach(item => {
+            const words = Object.values(item)[0] || [];
+            words.forEach(word => {
+                uniqueWords.set(word.topic_id, word);
+            });
+        });
         
-        return allWords;
-    };
-
-    // 添加清除缓存的方法
-    WordbookStorage.clearCache = function() {
-        cache = {
-            words: [],
-            timestamp: 0
-        };
-        console.log('单词缓存已清除');
-    };
-
-    // 在数据变更时清除缓存
-    const originalAdd = WordbookStorage.add;
-    WordbookStorage.add = async function(...args) {
-        const result = await originalAdd.apply(this, args);
-        WordbookStorage.clearCache();
-        return result;
-    };
-
-    const originalRemove = WordbookStorage.remove;
-    WordbookStorage.remove = async function(...args) {
-        const result = await originalRemove.apply(this, args);
-        WordbookStorage.clearCache();
-        return result;
-    };
-
-    const originalClear = WordbookStorage.clear;
-    WordbookStorage.clear = function() {
-        originalClear.call(this);
-        WordbookStorage.clearCache();
+        return Array.from(uniqueWords.values());
     };
 
     global.wordbookStorageModule = {WordbookStorage};

--- a/src/js/wordbook.js
+++ b/src/js/wordbook.js
@@ -284,5 +284,19 @@
         }
     }
 
+    async function getAllWords() {
+        try {
+            const allWords = await WordbookStorage.loadAllWords();
+            
+            // 可以按时间排序
+            allWords.sort((a, b) => b.created_at - a.created_at);
+            
+            return allWords;
+        } catch(e) {
+            console.error('获取所有单词失败', e);
+            return [];
+        }
+    }
+
     window.wordbookModule = {init};
 } (this, document, jQuery));


### PR DESCRIPTION
# 主要修改内容

1. 支持多个单词本中的单词高亮和Anki导出
    原有实现只支持高亮或导出一个单词本中的内容，而且单词本的可以收藏的单词最多 3000 个。此次提交支持高亮所有单词本的单词，以及导出所有单词本的单词到 Anki 软件。解决思路：先搜集所有单词本的单词，再做高亮或导出。
2. 取消高亮 1000 个单词的限制。优化了高亮策略，超出 1000 个单词高亮也能很快处理。
3. 解决一个 Anki 导出的一个设置问题
4. 解决了以下可能需要优化的点所列出的问题


<del>  # 可能需要优化点 </del>

<del>1. 如果高亮的单词不在当前收藏单词本中，收藏按钮不会显示已收藏。这样对以熟悉的单词取消收藏不太友好。暂时还没想到什么好的解决方案</del>
![image](https://github.com/user-attachments/assets/4e0c01ec-c5c3-4124-8213-d98ef93d4be4)

<del>2. 当单词本收藏的接近 3000 个，在单词本中取消收藏，刷新后还在收藏列表中（实际百词斩中已经取消收藏了）暂时还没找到问题原因，怀疑是设置中选定的单词本不是我取消收藏的单词所在的单词本。</del>